### PR TITLE
Check ClusterRole resources in cluster in configuration phase

### DIFF
--- a/pkg/configure_path.go
+++ b/pkg/configure_path.go
@@ -114,6 +114,11 @@ func (b *backend) handleConfigWrite(ctx context.Context, req *logical.Request, d
 		return logical.ErrorResponse("Configuration not valid: %s", err), err
 	}
 
+	// Check ClusterRole resources in k8s cluster
+	if err := b.kubernetesService.CheckClusterRoleResources(&config); err != nil {
+		return nil, fmt.Errorf("Error: %s", err)
+	}
+
 	entry, err := logical.StorageEntryJSON(configPath, config)
 	if err != nil {
 		return nil, err

--- a/pkg/kubernetes_interface.go
+++ b/pkg/kubernetes_interface.go
@@ -2,6 +2,9 @@ package servian
 
 // KubernetesInterface defines the core functions for the Kubernetes integration
 type KubernetesInterface interface {
+	// CheckClusterRoleResources checks if ClusterRole resource exists for each role
+	CheckClusterRoleResources(pluginConfig *PluginConfig) error
+
 	// CreateServiceAccount creates a new service account
 	CreateServiceAccount(pluginConfig *PluginConfig, namespace string) (*ServiceAccountDetails, error)
 

--- a/pkg/kubernetes_service.go
+++ b/pkg/kubernetes_service.go
@@ -20,6 +20,25 @@ const roleKind = "Role"
 // KubernetesService is an empty struct to wrap the Kubernetes service functions
 type KubernetesService struct{}
 
+// CheckClusterRoleResources checks if ClusterRole resource exists for each role
+func (k *KubernetesService) CheckClusterRoleResources(pluginConfig *PluginConfig) error {
+	clientSet, err := getClientSet(pluginConfig)
+	if err != nil {
+		return err
+	}
+
+	roles := []string{pluginConfig.AdminRole, pluginConfig.EditorRole, pluginConfig.ViewerRole}
+
+	for _, role := range roles {
+		_, err = clientSet.RbacV1().ClusterRoles().Get(role, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // CreateServiceAccount creates a new service account
 func (k *KubernetesService) CreateServiceAccount(pluginConfig *PluginConfig, namespace string) (*ServiceAccountDetails, error) {
 	clientSet, err := getClientSet(pluginConfig)


### PR DESCRIPTION
I think this check will not only check if ClusterRole resources exist but also will check cluster connectivity too.
So, we can use this PR instead of the previous with "get nodes" logic.

Checking specific permissions may be on top of this (to create SA and RoleBinding resources).

```
Error writing data to k8s/config: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/k8s/config
Code: 500. Errors:

* 1 error occurred:
	* Error: clusterroles.rbac.authorization.k8s.io "editor_role2" not found
```

```
Error writing data to k8s/config: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/k8s/config
Code: 500. Errors:

* 1 error occurred:
	* Error: Unauthorized
```